### PR TITLE
Fix expiration date

### DIFF
--- a/src/boleto.js
+++ b/src/boleto.js
@@ -151,7 +151,7 @@ class Boleto {
    * @return {Date} The expiration date of the bank slip
    */
   expirationDate() {
-    const refDate = new Date('1997-10-07');
+    const refDate = new Date('1997-10-07 12:00:00 GMT-0300');
     const days = this.barcode().substr(5, 4);
 
     return new Date(refDate.getTime() + (days * 86400000));

--- a/test/boleto.test.js
+++ b/test/boleto.test.js
@@ -186,7 +186,7 @@ describe('Boleto.js', () => {
 
   describe('#expirationDate()', () => {
     it('should return correct expiration date', () => {
-      expect(bankslip.expirationDate()).toEqual(new Date('2020-11-16'));
+      expect(bankslip.expirationDate()).toEqual(new Date('2020-11-16 12:00:00 GMT-0300'));
     });
   });
 


### PR DESCRIPTION
When converting the date to text, depending on the timezone, it could display the wrong day.
This forces the reference date to be at noon BRT, which should prevent this from happening.